### PR TITLE
Initialize ssg-go as separate repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,52 @@
+name: build go
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  push:
+
+jobs:
+  test:
+    name: Build go binaries
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+
+        go-version:
+          - stable
+          - "" # empty string = read version from go.mod
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      ARTIFACT_SSG_GO: "ssg-go-bin-go${{ matrix.go-version }}_${{ matrix.os }}"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+        with:
+          fetch-depth: "0"
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          go-version-file: "./go.mod"
+          cache: false
+          check-latest: true
+
+      - name: Build ssg-go
+        run: |
+          echo "PWD: $pwd"
+          mkdir -p $ARTIFACT_SSG_GO
+          echo 'Building ssg-go/ssg'
+          go build -o $ARTIFACT_SSG_GO/ssg ./cmd/ssg
+
+      - name: Upload Go build results
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_result-go${{ matrix.go-version }}_${{ matrix.os }}
+          path: ${{ env.ARTIFACT_SSG_GO }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,122 @@
+on:
+  release:
+    types: [created]
+
+  push:
+    branches:
+      - master
+
+    tags:
+      - 'v*'
+      - 'rc-*'
+      - 'dev-*'
+      - 'test-*'
+
+name: Release ssg-go
+jobs:
+  generate:
+    name: Build ssg-go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for build
+        uses: actions/checkout@master
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build ssg-go from flake
+        run: |
+          nix build .#default
+
+      - name: Zip ssg-go binaries
+        run: |
+          zip -r ssg-go-x86_64_linux.zip result/bin
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: ssg-go-zip
+          path: ./ssg-go-x86_64_linux.zip
+
+  release-tag:
+    if: ${{ github.ref_type  == 'tag' }}
+    name: Release from tag
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
+
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-go-zip
+          path: ./
+      
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ssg-go-x86_64_linux.zip
+          asset_name: ssg-go-x86_64_linux.zip
+          asset_content_type: application/zip
+
+  release-branch:
+    if: ${{ github.ref_type  == 'branch' }}
+    name: Release from branch
+    needs: generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
+
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-go-zip
+          path: ./
+      
+      - name: Get today's date
+        run: |
+          # Store 2025-01-01 in env $RELEASE_DATE
+          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Create Release for branch ${{ github.ref_name }}
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
+          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ssg-go-x86_64_linux.zip
+          asset_name: ssg-go-x86_64_linux.zip
+          asset_content_type: application/zip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,49 @@
+name: test
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    name: Test code
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+
+        go-version:
+          - stable
+          - "" # empty string = read version from go.mod
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      ARTIFACT_SSG_GO: "ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+        with:
+          fetch-depth: "0"
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          go-version-file: "./go.mod"
+          cache: false
+          check-latest: true
+
+      - name: Test ssg-go
+        run: |
+          echo "PWD: $pwd"
+          echo "Testing ssg-go and writing JSON report to $ARTIFACT_SSG_GO"
+          go test -race -count=1 -json ./... > $ARTIFACT_SSG_GO
+
+      - name: Upload Go test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_result-go${{ matrix.go-version }}_${{ matrix.os }}
+          path: ${{ env.ARTIFACT_SSG_GO }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Nix build result
+/result
+
+/cmd/debug
+
+testdata/johndoe.com/*
+!testdata/johndoe.com/src
+testdata/johndoe.com/src/style.css
+testdata/johndoe.com/src/style-copy*
+testdata/johndoe.com/src/some-txt.txt
+testdata/johndoe.com/src/drop
+testdata/johndoe.com/src/assets
+
+testdata/myblog/*
+!testdata/myblog/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+
+# Install git and ca-certificates (needed for go mod download)
+RUN apk add --no-cache git ca-certificates tzdata
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o ssg ./cmd/ssg
+
+# Final stage
+FROM alpine:latest
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+# Create non-root user
+RUN addgroup -g 1001 -S ssg && \
+    adduser -u 1001 -S ssg -G ssg
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder stage
+COPY --from=builder /app/ssg .
+
+# Change ownership to non-root user
+RUN chown ssg:ssg /app/ssg
+
+# Switch to non-root user
+USER ssg
+
+# Expose port (if needed for future web interface)
+EXPOSE 8080
+
+# Set the binary as entrypoint
+ENTRYPOINT ["./ssg"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,192 @@
+# ssg-go
+
+ssg-go is a drop-in replacement and library for implementing ssg.
+
+## Extending and consuming ssg-go
+
+### ssg-go walk
+
+Given `src` and `dst` paths, ssg-go walks `src` and performs the
+following operations for each source file:
+
+- If path is ignored
+
+  ssg-go continues to the next input.
+
+- If path is unignored directory
+
+  ssg-go collects templates from `_header.html` and `_footer.html`
+
+- If path is an unignored file
+
+  ssg-go reads the data and send it to all of the `Pipeline`s.
+
+  The output from the last `Pipeline` is used as input to ssg-go *core*,
+  which handles the Markdown conversion and assembly of HTML outputs.
+
+  ```
+  raw_data -> [pipelines] -> [core] -> output
+  ```
+
+  Pipelines can use these 2 well known errors control ssg-go walk control flow:
+
+  - `ErrBreakPipelines`
+
+    ssg-go stops going through pipelines and immedietly advances to core
+
+  - `ErrSkipCore`
+
+    Like with `ErrBreakPipelines`, but ssg-go also skips core.
+
+### ssg-go core
+
+For an input file, ssg-go performs these actions:
+
+- If path is a file
+
+  ssg-go calls `Hook` on the file to modify the data.
+  We can use minifiers here.
+
+- If path has non-`.md` extension
+
+  ssg-go will not convert it to HTML,
+  and it will simply mirror the file to `$dst`:
+
+  ```
+  core_input -> [hook] -> output
+  ```
+
+- If path has `.md` extension
+
+  ssg-go assembles and adds the HTML output to the outputs.
+  After the assembly, `HookGenerate` is called on the data.
+
+  ```
+  core_input -> [hook] -> [covert-to-html] -> [hookGenerate] -> output
+  ```
+
+### Options
+
+Go programmers can extend ssg-go via the [`Option` type](./options.go).
+
+[soyweb](../soyweb/) also extends ssg via `Option`,
+and provides extra functionality such as index generator and minifiers.
+
+Extending via options can be done in 2 rough categories:
+
+- Hooks
+
+  Hooks modify file content in-place in memory (without renaming input files).
+  In short, it maps the input bytes 1-1 to new input bytes.
+
+  A good usecase for hooks would be minifiers or content filter.
+
+- Pipelines
+
+  Pipelines have full control of the walk, and can arbitarily generate new
+  ssg-go outputs and change input properties such as filenames and modes.
+
+  In soyweb, pipelines are used to implement the [index generator](../soyweb/index.go).
+
+#### `Hook` option
+
+`Hook` is a Go function used to modify data after it is read,
+preserving the filename. `Hook` is only called on the raw inputs
+but not on the generated HTMLs.
+
+It is enabled with `WithHook(hook)`
+
+#### `HookGenerate` option
+
+`HookGenerate` is a Go function called on every generated HTML.
+For example, soyweb uses this option to implement output minifier.
+
+It is enabled with `WithHookGenerate(hook)`
+
+#### `Pipeline` option
+
+`Pipeline` is a Go function called on a file during directory walk.
+To reduce complexity, ignored files and ssg headers/footers are not sent
+to `Pipeline`. This preserves the core functionality of the original ssg.
+
+Pipelines can be chained together with `WithPipelines(p1, p2, p3)`
+
+`WithPipelines` accepts 2 types of spread parameters:
+
+- `Pipeline`
+
+  An alias to `func(path string, data []byte, d fs.DirEntry) (string, []byte, fs.DirEntry, error)`
+  We can call these pipelines *pure* pipelines.
+
+  An example would be this `Pipeline`, that reads atime from filesystems
+  and prepends the date string to Markdowns:
+
+  ```go
+  func pipelineUpdatedAt(path string, data []byte, d fs.DirEntry) (string, []byte, fs.DirEntry, error) {
+  	if d.IsDir() {
+  		return path, data, d, nil
+  	}
+  	if filepath.Ext(path) != ".md" {
+  		return path, data, d, nil
+  	}
+  	info, err := d.Info()
+  	if err != nil {
+  		return "", nil, nil, err
+  	}
+  	buf := bytes.NewBufferString(
+  		fmt.Sprintf("%s", info.ModTime().Format(time.DateOnly)),
+  	)
+
+  	buf.ReadFrom(bytes.NewBuffer(data))
+  	return path, buf.Bytes(), d, nil
+  }
+  ```
+
+- `func(s *Ssg) Pipeline`
+
+  Some pipelines are not pure and might need something from `Ssg`, so
+  we allow these pipeline constructors as arguments to `WithPipelines`.
+
+  An example for this type of pipelines would be the [index generator](../soyweb/index.go),
+  which needs to know which files are ignored in addition to `$src` and `$dst`.
+
+### Streaming and caching builds
+
+To minimize runtime memory usage, ssg-go builds and writes concurrently.
+There're 2 main ssg threads: one is for building the outputs,
+and the other is the write thread.
+
+The build thread *sequentially* reads, builds and sends outputs
+to the write thread via a buffered Go channel.
+
+Bufffering allows the builder thread to continue to build and send outputs
+to the writer until the buffer is full.
+
+This helps reduce back pressure, and keeps memory usage low.
+The buffer size is, by default, 2x of the number of writers.
+
+This means that, at any point in time during a generation of any number of files
+with 20 writers, ssg-go will at most only hold 40 output files
+in memory (in the buffered channel).
+
+If you are importing ssg-go to your code and you don't want this
+streaming behavior, you can use the exposed function `Build`, `WriteOutSlice`,
+and `GenerateMetadata`:
+
+```go
+files, dist, err := ssg.Build(src, dst, title, url)
+if err != nil {
+  panic(err)
+}
+
+err = ssg.WriteOutSlice(dist)
+if err != nil {
+  panic(err)
+}
+
+err = GenerateMetadata(src, dst, urk, files, dist, time.Now())
+if err != nil {
+  panic(err)
+}
+```
+

--- a/build.go
+++ b/build.go
@@ -1,0 +1,85 @@
+package ssg
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+func build(s *Ssg, o Outputs) ([]string, []OutputFile, error) {
+	s.result = buildOutput{
+		cacheOutput: s.options.caching,
+		writer:      o,
+	}
+	err := filepath.WalkDir(s.Src, s.walk)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.result.files, s.result.cache, nil
+}
+
+func (s *Ssg) walk(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+	if d.IsDir() {
+		return s.collect(path)
+	}
+
+	base := filepath.Base(path)
+	ignore, err := shouldIgnore(s.ssgignores, path, base, d)
+	if err != nil {
+		return err
+	}
+	if ignore {
+		return nil
+	}
+
+	switch base {
+	case
+		MarkerHeader,
+		MarkerFooter,
+		SsgIgnore:
+
+		return nil
+	}
+
+	data, err := ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Remember input files for .files
+	//
+	// Original ssg does not include _header.html
+	// and _footer.html in .files
+	s.result.files = append(s.result.files, path)
+
+	skipCore := false
+	for i, p := range s.options.pipelines {
+		path, data, d, err = p(path, data, d)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, ErrSkipCore) {
+			skipCore = true
+			break
+		}
+		if errors.Is(err, ErrBreakPipelines) {
+			break
+		}
+		return fmt.Errorf("[pipeline %d] error: %w", i, err)
+	}
+
+	if skipCore {
+		return nil
+	}
+
+	output, err := s.core(path, data, d)
+	if err != nil {
+		return fmt.Errorf("core error: %w", err)
+	}
+	s.result.Add(output)
+	return nil
+}

--- a/cmd/ssg/main.go
+++ b/cmd/ssg/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/soyart/ssg-go"
+)
+
+func main() {
+	if len(os.Args) < 5 {
+		ssg.Fprint(os.Stdout, "usage: ssg src dst title base_url\n")
+		syscall.Exit(1)
+	}
+
+	src, dst, title, url := os.Args[1], os.Args[2], os.Args[3], os.Args[4]
+	err := ssg.Generate(
+		src, dst, title, url,
+		ssg.WritersFromEnv(),
+	)
+	if err != nil {
+		ssg.Fprintln(os.Stdout, "error with", "src", src, "dst", dst, "title", title, "url", url)
+		panic(err)
+	}
+}

--- a/common.go
+++ b/common.go
@@ -1,0 +1,265 @@
+package ssg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+)
+
+type (
+	Set map[string]struct{}
+
+	// perDir tracks files under directory in a trie-like fashion.
+	// Used to choose headers and footers.
+	perDir[T any] struct {
+		defaultValue T
+		values       map[string]T
+	}
+
+	header struct {
+		*bytes.Buffer
+		titleFrom TitleFrom
+	}
+
+	headers struct {
+		perDir[header]
+	}
+
+	footers struct {
+		perDir[*bytes.Buffer]
+	}
+)
+
+// ToHtml converts md (Markdown) into HTML document
+func ToHtml(md []byte) []byte {
+	root := markdown.Parse(md, parser.NewWithExtensions(SsgExtensions))
+	renderer := html.NewRenderer(html.RendererOptions{
+		Flags: HtmlFlags,
+	})
+	return markdown.Render(root, renderer)
+}
+
+func FileIs(f os.FileInfo, mode fs.FileMode) bool {
+	return f.Mode()&mode != 0
+}
+
+func ChangeExt(path, old, new string) string {
+	path = strings.TrimSuffix(path, old)
+	return path + new
+}
+
+func (s Set) Insert(v string) bool {
+	_, ok := s[v]
+	s[v] = struct{}{}
+	return ok
+}
+
+func (s Set) Contains(items ...string) bool {
+	for _, v := range items {
+		_, ok := s[v]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func Fprint(w io.Writer, data ...any) {
+	_, err := fmt.Fprint(w, data...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Fprintf(w io.Writer, format string, data ...any) {
+	_, err := fmt.Fprintf(w, format, data...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Fprintln(w io.Writer, data ...any) {
+	_, err := fmt.Fprintln(w, data...)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func Output(target string, originator string, data []byte, perm fs.FileMode) OutputFile {
+	return OutputFile{
+		target:     target,
+		originator: originator,
+		data:       data,
+		perm:       perm,
+	}
+}
+
+func (o *OutputFile) Target() string {
+	return o.target
+}
+
+func (o *OutputFile) Originator() string {
+	return o.originator
+}
+
+func (o *OutputFile) Data() []byte {
+	return o.data
+}
+
+func (o *OutputFile) Perm() fs.FileMode {
+	if o.perm == fs.FileMode(0) {
+		return fs.ModePerm
+	}
+	return o.perm
+}
+
+// WriteOutSlice blocks and writes concurrently from writes to their output locations.
+func WriteOutSlice(writes []OutputFile, concurrent int) error {
+	if concurrent == 0 {
+		concurrent = 1
+	}
+
+	wg := new(sync.WaitGroup)
+	errs := make(chan errorWrite)
+	guard := make(chan struct{}, concurrent)
+
+	for i := range writes {
+		guard <- struct{}{}
+		wg.Add(1)
+
+		go func(w *OutputFile, wg *sync.WaitGroup) {
+			defer func() {
+				<-guard
+				wg.Done()
+			}()
+
+			err := os.MkdirAll(filepath.Dir(w.target), os.ModePerm)
+			if err != nil {
+				errs <- errorWrite{
+					err:        err,
+					target:     w.target,
+					originator: w.originator,
+				}
+				return
+			}
+			err = os.WriteFile(w.target, w.data, w.Perm())
+			if err != nil {
+				errs <- errorWrite{
+					err:        err,
+					target:     w.target,
+					originator: w.originator,
+				}
+				return
+			}
+
+			Fprintln(os.Stdout, w.target)
+		}(&writes[i], wg)
+	}
+
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	var wErrs []error
+	for err := range errs { // Blocks here until errs is closed
+		wErrs = append(wErrs, err)
+	}
+	if len(wErrs) > 0 {
+		return errors.Join(wErrs...)
+	}
+
+	return nil
+}
+
+func newHeaders(defaultHeader string) headers {
+	return headers{
+		perDir: newPerDir(header{
+			Buffer:    bytes.NewBufferString(defaultHeader),
+			titleFrom: TitleFromH1,
+		}),
+	}
+}
+
+func newFooters(defaultFooter string) footers {
+	return footers{
+		perDir: newPerDir(bytes.NewBufferString(defaultFooter)),
+	}
+}
+
+func newPerDir[T any](defaultValue T) perDir[T] {
+	return perDir[T]{
+		defaultValue: defaultValue,
+		values:       make(map[string]T),
+	}
+}
+
+func (p *perDir[T]) add(path string, v T) error {
+	_, ok := p.values[path]
+	if ok {
+		return fmt.Errorf("found duplicate path '%s'", path)
+	}
+
+	p.values[path] = v
+	return nil
+}
+
+func (p *perDir[T]) choose(path string) T {
+	return choose(path, p.defaultValue, p.values)
+}
+
+// choose chooses which map value should be used for the given path.
+func choose[T any](path string, valueDefault T, m map[string]T) T {
+	chosen, ok := m[path]
+	if ok {
+		return chosen
+	}
+	parts := strings.Split(path, "/")
+	chosen, max := valueDefault, 0
+
+outer:
+	for prefix, stored := range m {
+		prefixes := strings.Split(prefix, "/")
+		for i := range parts {
+			if i >= len(prefixes) {
+				break
+			}
+			if parts[i] != prefixes[i] {
+				continue outer
+			}
+		}
+
+		l := len(prefix)
+		if max > l {
+			continue
+		}
+
+		chosen, max = stored, l
+	}
+
+	return chosen
+}
+
+type errorWrite struct {
+	err        error
+	target     string
+	originator string
+}
+
+func (e errorWrite) Error() string {
+	return fmt.Errorf("WriteError(target='%s',originator='%s'): %w", e.target, e.originator, e.err).Error()
+}

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,68 @@
+package ssg
+
+import "testing"
+
+func TestPerDir(t *testing.T) {
+	type testCase struct {
+		path     string
+		expected int
+	}
+
+	defaultValue := 0
+	pd := newPerDir(defaultValue)
+	pd.add("/1", 1)
+	pd.add("/1/2", 2)
+	pd.add("/10/20", 20)
+	pd.add("/10/20/30", 30)
+
+	tests := []testCase{
+		{
+			path:     "/",
+			expected: 0,
+		},
+		{
+			path:     "/1",
+			expected: 1,
+		},
+		{
+			path:     "/1/3",
+			expected: 1,
+		},
+		{
+			path:     "/1/2",
+			expected: 2,
+		},
+		{
+			path:     "/1/2.d",
+			expected: 1,
+		},
+		{
+			path:     "/1/2/foo",
+			expected: 2,
+		},
+		{
+			path:     "/10/20/foo",
+			expected: 20,
+		},
+		{
+			path:     "/10.1/20/foo",
+			expected: 0,
+		},
+		{
+			path:     "/10.1/20/30/foo/bar/baz/1",
+			expected: 0,
+		},
+		{
+			path:     "/10/20/30/foo/bar/baz/1",
+			expected: 30,
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+		actual := choose(tc.path, defaultValue, pd.values)
+		if tc.expected != actual {
+			t.Fatalf("unexpected value %v, expecting %v for path '%s'", actual, tc.expected, tc.path)
+		}
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,152 @@
+{
+  description = "Static site generator library - Go implementation";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    ssg-testdata = {
+      url = "github:soyart/ssg-testdata";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, ssg-testdata }:
+    let
+      homepage = "https://github.com/soyart/ssg-go";
+
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # The set of systems to provide outputs for
+      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      # A function that provides a system-specific Nixpkgs for the desired systems
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+
+    {
+      packages = forAllSystems ({ pkgs }: {
+        default = pkgs.buildGoModule {
+          inherit version;
+          pname = "ssg-go";
+          
+          src = ./.;
+          
+          # Go module configuration
+          vendorHash = "sha256-P8vB0khyNGjYNmYwn/AfzKyB+CaK/lhcMPsO9UmDNSQ="; # This will be updated by nix
+          
+          # Build configuration
+          buildPhase = ''
+            runHook preBuild
+            
+            # Ensure test data is available during build
+            ln -sf ${ssg-testdata} ./testdata
+            
+            # Build the main binary
+            go build -o $out/bin/ssg ./cmd/ssg
+            
+            runHook postBuild
+          '';
+          
+          # Install configuration
+          installPhase = ''
+            runHook preInstall
+            
+            mkdir -p $out/bin
+            cp ssg $out/bin/ssg
+            
+            runHook postInstall
+          '';
+          
+          # Test configuration
+          checkPhase = ''
+            runHook preCheck
+            
+            # Ensure test data is available for tests
+            ln -sf ${ssg-testdata} ./testdata
+            
+            # Run tests
+            go test -v ./...
+            
+            runHook postCheck
+          '';
+          
+          meta = {
+            inherit homepage;
+            description = "Static site generator library - Go implementation";
+            license = pkgs.lib.licenses.mit;
+            maintainers = [ ];
+            platforms = pkgs.lib.platforms.unix;
+          };
+        };
+
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # Nix development tools
+            nixd
+            nixpkgs-fmt
+            
+            # Go development tools
+            go
+            gopls
+            gotools
+            go-tools
+            
+            # Testing tools
+            ginkgo
+            gomega
+          ];
+          
+          # Environment variables
+          shellHook = ''
+            echo "ssg-go development environment"
+            echo "Go version: $(go version)"
+            echo "Test data will be available at ./testdata (submodule)"
+            
+            # Check if testdata submodule exists
+            if [ ! -d "./testdata" ]; then
+              echo "Warning: testdata submodule not found. Run:"
+              echo "  git submodule add https://github.com/soyart/ssg-testdata.git testdata"
+            fi
+          '';
+        };
+      });
+
+      # Nix flake checks
+      checks = forAllSystems ({ pkgs }: {
+        # Build check
+        build = self.packages.${pkgs.system}.default;
+        
+        # Test check
+        test = pkgs.runCommand "ssg-go-tests" {
+          nativeBuildInputs = with pkgs; [ go ];
+        } ''
+          cp -r ${self}/* .
+          chmod -R +w .
+          
+          # Ensure test data is available
+          ln -sf ${ssg-testdata} ./testdata
+          
+          # Run tests
+          go test -v -count=1 -race ./...
+          
+          touch $out
+        '';
+        
+        # Lint check
+        lint = pkgs.runCommand "ssg-go-lint" {
+          nativeBuildInputs = with pkgs; [ go-tools ];
+        } ''
+          cp -r ${self}/* .
+          chmod -R +w .
+          
+          # Run linter
+          golangci-lint run
+          
+          touch $out
+        '';
+      });
+    };
+}

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,133 @@
+package ssg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+func generate(s *Ssg) error {
+	const bufferMultiplier = 2
+	stat, err := os.Stat(s.Src)
+	if err != nil {
+		return fmt.Errorf("failed to stat src '%s': %w", s.Src, err)
+	}
+
+	stream := make(chan OutputFile, s.options.writers*bufferMultiplier)
+	outputs := NewOutputsStreaming(stream)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var errBuild error
+	var files []string
+	go func() {
+		defer func() {
+			close(stream)
+			wg.Done()
+		}()
+
+		var err error
+		files, _, err = s.Build(outputs)
+		if err != nil {
+			errBuild = err
+		}
+	}()
+
+	var written []OutputFile
+	var errWrites error
+	go func() {
+		defer wg.Done()
+		var err error
+
+		written, err = WriteOut(stream, s.options.writers)
+		if err != nil {
+			errWrites = err
+		}
+	}()
+
+	wg.Wait()
+
+	if errBuild != nil && errWrites != nil {
+		return fmt.Errorf("streaming_build_error='%w', streaming_write_error='%s'", errBuild, errWrites)
+	}
+	if errBuild != nil {
+		return fmt.Errorf("streaming_build_error: %w", errBuild)
+	}
+	if errWrites != nil {
+		return fmt.Errorf("streaming_write_error: %w", errWrites)
+	}
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, files, written, stat.ModTime())
+	if err != nil {
+		return err
+	}
+	s.pront(len(written) + 2)
+	return nil
+}
+
+// WriteOut blocks and concurrently writes outputs from stream until stream is closed.
+// It returns metadata for all outputs written, without the data.
+func WriteOut(stream <-chan OutputFile, concurrent int) ([]OutputFile, error) {
+	if concurrent == 0 {
+		concurrent = 1
+	}
+
+	written := make([]OutputFile, 0) // No data, only metadata
+	wg := new(sync.WaitGroup)
+	errs := make(chan errorWrite)
+	guard := make(chan struct{}, concurrent)
+	mut := new(sync.Mutex)
+
+	for w := range stream {
+		guard <- struct{}{}
+		wg.Add(1)
+
+		go func(w *OutputFile, wg *sync.WaitGroup) {
+			defer func() {
+				<-guard
+				wg.Done()
+			}()
+
+			err := os.MkdirAll(filepath.Dir(w.target), os.ModePerm)
+			if err != nil {
+				errs <- errorWrite{
+					err:        err,
+					target:     w.target,
+					originator: w.originator,
+				}
+				return
+			}
+			err = os.WriteFile(w.target, w.data, w.Perm())
+			if err != nil {
+				errs <- errorWrite{
+					err:        err,
+					target:     w.target,
+					originator: w.originator,
+				}
+				return
+			}
+
+			mut.Lock()
+			defer mut.Unlock()
+
+			written = append(written, Output(w.target, w.originator, nil, w.perm))
+			Fprintln(os.Stdout, w.target)
+		}(&w, wg)
+	}
+
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	var wErrs []error
+	for err := range errs { // Blocks here until errs is closed
+		wErrs = append(wErrs, err)
+	}
+	if len(wErrs) > 0 {
+		return nil, errors.Join(wErrs...)
+	}
+
+	return written, nil
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,151 @@
+package ssg
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGenerateStreaming tests that all files are properly flushed to destination when streaming,
+// and that all outputs are identical
+func TestGenerateStreaming(t *testing.T) {
+	root := "../testdata/johndoe.com"
+	src := filepath.Join(root, "/src")
+	dst := filepath.Join(root, "/dstBuild")
+	dstStreaming := filepath.Join(root, "/dstStreaming")
+	title := "JohnDoe.com"
+	url := "https://johndoe.com"
+
+	err := os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+	err = os.RemoveAll(dstStreaming)
+	if err != nil {
+		panic(err)
+	}
+
+	// Generate with streaming
+	streaming := New(src, dstStreaming, title, url)
+	streaming.With(Writers(uint(WritersDefault)))
+
+	// Generate without streaming, and with caching
+	// (old v2 flow)
+	caching := New(src, dst, title, url)
+	caching.With(
+		Caching(true),
+		Writers(uint(WritersDefault)),
+	)
+
+	testCmpDeepEqual(t, &caching, &streaming)
+}
+
+func testCmpDeepEqual(t *testing.T, s1, s2 *Ssg) {
+	err := os.RemoveAll(s1.Dst)
+	if err != nil {
+		panic(err)
+	}
+	err = os.RemoveAll(s2.Dst)
+	if err != nil {
+		panic(err)
+	}
+	err = s1.Generate()
+	if err != nil {
+		panic(err)
+	}
+	err = s2.Generate()
+	if err != nil {
+		panic(err)
+	}
+
+	testDeepEqual(t, s1.Dst, s2.Dst)
+}
+
+func testDeepEqual(t *testing.T, dst1, dst2 string) {
+	fn := deepEqual(t, dst1, dst2)
+	err := filepath.WalkDir(dst1, fn)
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.RemoveAll(dst1)
+	if err != nil {
+		panic(err)
+	}
+	err = os.RemoveAll(dst2)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func deepEqual(t *testing.T, dst1, dst2 string) fs.WalkDirFunc {
+	// Walk on s1, and compare with the same output from s2
+	return func(path1 string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dst1, path1)
+		if err != nil {
+			panic(err)
+		}
+
+		path2 := filepath.Join(dst2, rel)
+		if d.IsDir() {
+			entries, err := os.ReadDir(path1)
+			if err != nil {
+				panic(err)
+			}
+			entries2, err := os.ReadDir(path2)
+			if err != nil {
+				return err
+			}
+
+			if l, ls := len(entries), len(entries2); l != ls {
+				for i := range entries {
+					t.Logf("expected entry for %s: %s", path1, entries[i].Name())
+				}
+				t.Fatalf("unexpected len of entries in '%s': expected=%d, actual=%d", path2, l, ls)
+			}
+			for i := range entries {
+				name1 := entries[i].Name()
+				name2 := entries2[i].Name()
+
+				if name1 != name2 {
+					t.Fatalf("unexpected filename: expected='%s', actual='%s'", name1, name2)
+				}
+			}
+
+			return nil
+		}
+
+		stat1, err := os.Stat(path1)
+		if err != nil {
+			panic(err)
+		}
+		stat2, err := os.Stat(path2)
+		if err != nil {
+			t.Fatalf("unexpected error from stat '%s': %v", path2, err)
+		}
+		if sz, szStreaming := stat1.Size(), stat2.Size(); sz != szStreaming {
+			t.Fatalf("unexpected size from '%s': expected=%d, actual=%d", path2, sz, szStreaming)
+		}
+
+		bytesExpected, err := os.ReadFile(path1)
+		if err != nil {
+			panic(err)
+		}
+		bytesStreaming, err := os.ReadFile(path2)
+		if err != nil {
+			t.Fatalf("unexpected error from reading '%s'", path2)
+		}
+		if !bytes.Equal(bytesExpected, bytesStreaming) {
+			t.Logf("Expected:\n%s", bytesExpected)
+			t.Logf("Streaming:\n%s", bytesStreaming)
+			t.Fatalf("unexpected bytes from '%s'", path2)
+		}
+
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/soyart/ssg-go
+
+go 1.22.7
+
+require (
+	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b h1:EY/KpStFl60qA17CptGXhwfZ+k1sFNJIUNR8DdbcuUk=
+github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,121 @@
+package ssg
+
+import (
+	"bytes"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+func GenerateMetadata(
+	src string,
+	dst string,
+	url string,
+	files []string,
+	dist []OutputFile,
+	srcModTime time.Time,
+) error {
+	metadata, err := Metadata(src, dst, url, files, dist, srcModTime)
+	if err != nil {
+		return err
+	}
+	return WriteOutSlice(metadata, 2)
+}
+
+func Metadata(
+	src string,
+	dst string,
+	url string,
+	files []string,
+	dist []OutputFile,
+	srcModTime time.Time,
+) (
+	[]OutputFile,
+	error,
+) {
+	sort.Slice(dist, func(i, j int) bool {
+		return dist[i].target < dist[j].target
+	})
+	dotFiles, err := DotFiles(src, files)
+	if err != nil {
+		return nil, err
+	}
+	sitemap, err := Sitemap(dst, url, srcModTime, dist)
+	if err != nil {
+		return nil, err
+	}
+	return []OutputFile{
+		Output(filepath.Join(dst, "sitemap.xml"), "", []byte(sitemap), 0644),
+		Output(filepath.Join(dst, ".files"), "", []byte(dotFiles), 0644),
+	}, nil
+}
+
+// Sitemap returns content of ${dst}/sitemap.xml
+func Sitemap(
+	dst string,
+	url string,
+	modTime time.Time,
+	outputs []OutputFile,
+) (
+	string,
+	error,
+) {
+	dateStr := modTime.Format(time.DateOnly)
+	sm := bytes.NewBufferString(`<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9
+https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+`)
+	for i := range outputs {
+		o := &outputs[i]
+		target, err := filepath.Rel(dst, o.target)
+		if err != nil {
+			return sm.String(), err
+		}
+
+		Fprintf(sm, "<url><loc>%s/", url)
+
+		/* There're 2 possibilities for this
+		1. First is when the HTML is some/path/index.html
+		<url><loc>https://example.com/some/path/</loc><lastmod>2024-10-04</lastmod><priority>1.0</priority></url>
+
+		2. Then there is when the HTML is some/path/page.html
+		<url><loc>https://example.com/some/path/page.html</loc><lastmod>2024-10-04</lastmod><priority>1.0</priority></url>
+		*/
+
+		base := filepath.Base(target)
+		switch base {
+		case "index.html":
+			d := filepath.Dir(target)
+			if d != "." {
+				Fprintf(sm, "%s/", d)
+			}
+		default:
+			sm.WriteString(target)
+		}
+
+		Fprintf(sm, "><lastmod>%s</lastmod><priority>1.0</priority></url>\n", dateStr)
+	}
+
+	sm.WriteString("</urlset>\n")
+	return sm.String(), nil
+}
+
+// DotFiles returns content of ${dst}/.files
+func DotFiles(src string, files []string) (string, error) {
+	list := bytes.NewBuffer(nil)
+	for _, f := range files {
+		if f == "" {
+			panic("found empty file for .files")
+		}
+		rel, err := filepath.Rel(src, f)
+		if err != nil {
+			return "", err
+		}
+
+		Fprintf(list, "./%s\n", rel)
+	}
+	return list.String(), nil
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,136 @@
+package ssg
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"reflect"
+	"strconv"
+)
+
+type (
+	Option func(*Ssg)
+
+	// Hook takes in a path and reads file data,
+	// returning modified output to be written at destination
+	Hook func(path string, data []byte) (output []byte, err error)
+
+	// HookGenerate takes in converted HTML bytes
+	// and returns modified HTML output (e.g. minified) to be written at destination
+	HookGenerate func(generatedHtml []byte) (output []byte, err error)
+
+	// Pipeline is called for each visit during a dir walk.
+	// ssg-go provides for pipeline the path and data the file being visited,
+	// and Pipeline is free to do whatever it wants with that information.
+	// The pipeline could use ErrSkipCore or ErrBreakPipelines as return value
+	// to control subsequent operations of the walk.
+	Pipeline func(path string, data []byte, d fs.DirEntry) (string, []byte, fs.DirEntry, error)
+
+	Options interface {
+		Hooks() []Hook
+		HooksGenerate() []HookGenerate
+		Pipelines() []Pipeline
+		Caching() bool
+		Writers() int
+	}
+
+	options struct {
+		// outputs      Outputs
+		hooks        []Hook
+		hookGenerate []HookGenerate
+		pipelines    []Pipeline
+		caching      bool
+		writers      int
+	}
+)
+
+func (o options) Hooks() []Hook                 { return o.hooks }
+func (o options) HooksGenerate() []HookGenerate { return o.hookGenerate }
+func (o options) Pipelines() []Pipeline         { return o.pipelines }
+func (o options) Caching() bool                 { return o.caching }
+func (o options) Writers() int                  { return o.writers }
+
+// WritersFromEnv returns an option that sets the parallel writes
+// to whatever [GetEnvWriters] returns
+func WritersFromEnv() Option {
+	return func(s *Ssg) {
+		writes := GetEnvWriters()
+		s.options.writers = int(writes)
+	}
+}
+
+// GetEnvWriters returns ENV value for parallel writes,
+// or default value if illgal or undefined
+func GetEnvWriters() int {
+	writesEnv := os.Getenv(WritersEnvKey)
+	writes, err := strconv.ParseUint(writesEnv, 10, 32)
+	if err == nil && writes != 0 {
+		return int(writes)
+	}
+
+	return WritersDefault
+}
+
+// Caching allows outputs to be built and retained for later use.
+// This is enabled in [Build].
+func Caching(b bool) Option {
+	return func(s *Ssg) { s.options.caching = b }
+}
+
+// Writers set the number of concurrent output writers.
+func Writers(u uint) Option {
+	return func(s *Ssg) { s.options.writers = int(u) }
+}
+
+// func WithOutputs(c chan<- OutputFile) Option {
+// 	return func(s *Ssg) { s.options.outputs = NewOutputs(c) }
+// }
+
+// WithHooks will make [Ssg] iterate through hooks and call hook(path, fileContent)
+// on every unignored files.
+func WithHooks(hooks ...Hook) Option {
+	return func(s *Ssg) { s.options.hooks = append(s.options.hooks, hooks...) }
+}
+
+// PrependHooks prepends [hooks] to Ssg's existing hook options.
+// e.g. if we have a Ssg with existing hook options = [hook1, hook2]
+// then PrependHooks(hook3, hook4) will make
+func PrependHooks(hooks ...Hook) Option {
+	return func(s *Ssg) {
+		hooks = append(hooks, s.options.hooks...)
+		s.options.hooks = hooks
+	}
+}
+
+// WithHooksGenerate assigns hook to be called on full output of files
+// that will be converted by ssg from Markdown to HTML.
+func WithHooksGenerate(hooks ...HookGenerate) Option {
+	return func(s *Ssg) { s.options.hookGenerate = append(s.options.hookGenerate, hooks...) }
+}
+
+// WithPipelines returns an option that allows caller
+// to set the pipeline(s) chained together for each file visit,
+// in a fashion similar to middlewares in HTTP frameworks.
+//
+// pipelines can be of type Pipeline or func(*Ssg) Pipeline
+func WithPipelines(pipes ...any) Option {
+	return func(s *Ssg) {
+		pipelines := make([]Pipeline, len(pipes))
+		for i, p := range pipes {
+			switch pipe := p.(type) {
+			case Pipeline:
+				pipelines[i] = pipe
+
+			case func(string, []byte, fs.DirEntry) (string, []byte, fs.DirEntry, error):
+				pipelines[i] = pipe
+
+			case func(*Ssg) Pipeline:
+				pipelines[i] = pipe(s)
+
+			default:
+				panic(fmt.Errorf("unexpected pipelines[%d] type '%s'", i, reflect.TypeOf(p).String()))
+			}
+		}
+		s.options.pipelines = pipelines
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,284 @@
+package ssg_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/soyart/ssg-go"
+)
+
+func TestPrependHooks(t *testing.T) {
+	var hook1 ssg.Hook = func(_ string, _ []byte) (_ []byte, _ error) { return []byte("hook1"), nil }
+	var hook2 ssg.Hook = func(_ string, _ []byte) (_ []byte, _ error) { return []byte("hook2"), nil }
+	var hook3 ssg.Hook = func(_ string, _ []byte) (_ []byte, _ error) { return []byte("hook3"), nil }
+	var hook4 ssg.Hook = func(_ string, _ []byte) (_ []byte, _ error) { return []byte("hook4"), nil }
+
+	assert := func(t *testing.T, s *ssg.Ssg) {
+		hooks := s.Options().Hooks()
+		for i := range hooks {
+			var result []byte
+
+			switch i {
+			case 0:
+				result, _ = hooks[i]("", nil)
+				if string(result) == "hook1" {
+					continue
+				}
+			case 1:
+				result, _ = hooks[i]("", nil)
+				if string(result) == "hook2" {
+					continue
+				}
+			case 2:
+				result, _ = hooks[i]("", nil)
+				if string(result) == "hook3" {
+					continue
+				}
+			case 3:
+				result, _ = hooks[i]("", nil)
+				if string(result) == "hook4" {
+					continue
+				}
+
+			default:
+				t.Errorf("unexpected index %d", i)
+			}
+
+			t.Errorf("unexpected value for hooks[%d]: %s", i, result)
+		}
+	}
+
+	t.Run("imperative", func(t *testing.T) {
+		s := new(ssg.Ssg)
+		s.With(ssg.WithHooks(hook3, hook4))
+		prepend := ssg.PrependHooks(hook1, hook2)
+		s.With(prepend)
+		assert(t, s)
+	})
+
+	t.Run("option slice", func(t *testing.T) {
+		var opts []ssg.Option
+		original := ssg.WithHooks(hook3, hook4)
+		prepend := ssg.PrependHooks(hook1, hook2)
+		opts = append(opts, original, prepend)
+
+		s := new(ssg.Ssg)
+		s.With(opts...)
+		assert(t, s)
+	})
+
+	t.Run("option slice rev", func(t *testing.T) {
+		var opts []ssg.Option
+		original := ssg.WithHooks(hook3, hook4)
+		prepend := ssg.PrependHooks(hook1, hook2)
+		opts = append(opts, prepend, original)
+
+		s := new(ssg.Ssg)
+		s.With(opts...)
+		assert(t, s)
+	})
+}
+
+// inputHasher computes and stamps hash for input files.
+// If the hash cannot be computed, the hasher output is ignored
+//
+// For the output file ${dst}/foo/bar.html generated
+// from ${src}/foo/bar.md, a hash file ${dst}/foo/bar.md.sha256
+// will be generated.
+func inputHasher(s *ssg.Ssg) ssg.Pipeline {
+	return func(path string, data []byte, d fs.DirEntry) (string, []byte, fs.DirEntry, error) {
+		if d.IsDir() {
+			return path, data, d, nil
+		}
+
+		var err error
+		hashPath := path + ".sha256"
+		hashPath, err = mirrorPath(s.Src, s.Dst, hashPath)
+		if err != nil {
+			return path, data, d, nil
+		}
+		hash, err := hashData(data)
+		if err != nil {
+			return path, data, d, nil
+		}
+
+		s.Outputs().Add(ssg.Output(hashPath, path, []byte(hash), 0o644))
+		return path, data, d, nil
+	}
+}
+
+func hashData(data []byte) (string, error) {
+	// TODO: init once
+	hash := sha256.New().Sum(data)
+	if len(hash) == 0 {
+		return "", nil
+	}
+	return hex.EncodeToString(hash), nil
+}
+
+func mirrorPath(src, dst, path string) (string, error) {
+	path, err := filepath.Rel(src, path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dst, path), nil
+}
+
+// Change all filenames except for index.md(s)
+func pipeChangeFilename(path string, data []byte, d fs.DirEntry) (string, []byte, fs.DirEntry, error) {
+	if d.IsDir() {
+		return path, data, d, nil
+	}
+	base := filepath.Base(path)
+	if base == "index.md" {
+		return path, data, d, nil
+	}
+	return changeFilename(path), data, d, nil
+}
+
+func changeFilename(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+
+	base = strings.TrimSuffix(base, ext) + "_mw_change_filename"
+	parent := filepath.Dir(path)
+
+	return filepath.Join(parent, fmt.Sprintf("%s%s", base, ext))
+}
+
+func TestChainPipelines(t *testing.T) {
+	src := "../testdata/myblog/src"
+	dst := "../testdata/myblog/dst-chain-pipes"
+
+	err := os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+	ignore, err := ssg.ParseSsgIgnore(filepath.Join(src, ssg.SsgIgnore))
+	if err != nil {
+		panic(err)
+	}
+
+	ssg.Generate(src, dst, "TestChainPipelines", "https://chain.pipes",
+		ssg.WithPipelines(
+			pipeChangeFilename,
+			inputHasher,
+
+			// The last pipeline skips output for svg files
+			func(path string, data []byte, d fs.DirEntry) (string, []byte, fs.DirEntry, error) {
+				if d.IsDir() {
+					return path, data, d, nil
+				}
+				if filepath.Ext(path) == ".svg" {
+					return path, data, d, ssg.ErrSkipCore
+				}
+				return path, data, d, nil
+			},
+		),
+	)
+
+	// For file in src (e.g. name.old_ext),
+	// we must have 2 corresponding files:
+	//
+	// ${name}_mw_change_filename.${old_ext}
+	// ${name}_mw_change_filename.${old_ext}.sha256
+	filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ignore.Ignore(path) {
+			return nil
+		}
+		mirrored, err := mirrorPath(src, dst, path)
+		if err != nil {
+			panic(err)
+		}
+
+		base := filepath.Base(path)
+		switch base {
+		case
+			ssg.MarkerHeader,
+			ssg.MarkerFooter,
+			ssg.SsgIgnore:
+
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			panic(err)
+		}
+		rehash, err := hashData(data)
+		if err != nil {
+			panic(err)
+		}
+
+		// index.md(s) names are not changed
+		if base == "index.md" {
+			// dst/foo/path/index.md.sha256
+			hashPath := mirrored + ".sha256"
+			stat, err := os.Stat(hashPath)
+			if err != nil {
+				t.Fatalf("failed to stat hash %s", hashPath)
+			}
+			if stat.IsDir() {
+				t.Fatalf("unexpected dir at hash path %s", hashPath)
+			}
+			hashed, err := os.ReadFile(hashPath)
+			if err != nil {
+				t.Fatalf("failed to read hash %s", hashPath)
+			}
+
+			if !bytes.Equal(hashed, []byte(rehash)) {
+				t.Fatalf("unexpected hash")
+			}
+			return nil
+		}
+
+		// file whose name was changed
+		target := changeFilename(mirrored)
+		target1 := target
+		if strings.HasSuffix(target, ".md") {
+			target1 = strings.TrimSuffix(target, ".md") + ".html"
+		}
+
+		if filepath.Ext(target1) == ".svg" {
+			_, err = os.Stat(target1)
+			if !os.IsNotExist(err) {
+				t.Fatalf("expecting to not exist: originator='%s', mirrored='%s', target='%s'", path, mirrored, target)
+			}
+			return nil
+		}
+
+		_, err = os.Stat(target1)
+		if err != nil {
+			t.Fatalf("failed to stat file: originator='%s', mirrored='%s', target='%s'", path, mirrored, target)
+		}
+
+		hashPath := target + ".sha256"
+		hashed, err := os.ReadFile(hashPath)
+		if err != nil {
+			t.Fatalf("failed to read file: originator='%s', mirrored='%s', target='%s'", path, mirrored, target)
+		}
+		if !bytes.Equal(hashed, []byte(rehash)) {
+			t.Fatalf("unexpected hash")
+		}
+
+		return nil
+	})
+
+	err = os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/output.go
+++ b/output.go
@@ -1,0 +1,52 @@
+package ssg
+
+import "io/fs"
+
+// OutputFile is the main output struct for ssg-go.
+//
+// Its values are not supposed to be changed by other packages,
+// and thus the only ways other packages can work with OutputFile
+// is via the constructor [Output] and the type's getter methods.
+type OutputFile struct {
+	target     string
+	originator string
+	data       []byte
+	perm       fs.FileMode
+}
+
+// Outputs is any collection out OutputFile.
+// It could be a simple Go slice that later get iterated and written to disk,
+// or a channel (as with outputsV1)
+type Outputs interface {
+	Add(...OutputFile)
+}
+
+type outputsV1 struct {
+	stream chan<- OutputFile
+}
+
+type buildOutput struct {
+	cacheOutput bool
+	writer      Outputs      // Main outputs
+	files       []string     // Input files read (not ignored)
+	cache       []OutputFile // Cache of main outputs
+}
+
+func NewOutputsStreaming(c chan<- OutputFile) Outputs {
+	return outputsV1{stream: c}
+}
+
+func (o outputsV1) Add(outputs ...OutputFile) {
+	for i := range outputs {
+		o.stream <- outputs[i]
+	}
+}
+
+func (b *buildOutput) Add(outputs ...OutputFile) {
+	if b.cacheOutput {
+		b.cache = append(b.cache, outputs...)
+	}
+	if b.writer != nil {
+		b.writer.Add(outputs...)
+	}
+}

--- a/ssg.go
+++ b/ssg.go
@@ -1,0 +1,376 @@
+package ssg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+const (
+	MarkerHeader = "_header.html"
+	MarkerFooter = "_footer.html"
+	SsgIgnore    = ".ssgignore"
+
+	WritersEnvKey      = "SSG_WRITERS"
+	WritersDefault int = 20
+
+	HtmlFlags     = html.CommonFlags
+	SsgExtensions = parser.CommonExtensions |
+		parser.Mmark |
+		parser.AutoHeadingIDs
+
+	HeaderDefault = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{from-h1}}</title>
+</head>
+<body>
+`
+	FooterDefault = `</body>
+</html>
+`
+)
+
+var (
+	// ErrBreakPipelines causes Ssg to break from pipeline iteration
+	// and use the pipeline's output
+	ErrBreakPipelines = errors.New("ssg_break_pipeline")
+
+	// ErrSkipCore causes Ssg to break from pipeline iteration
+	// and skip core processor, continuing to the new input file.
+	ErrSkipCore = errors.New("ssg_skip_core")
+)
+
+type Ssg struct {
+	Src   string
+	Dst   string
+	Title string
+	Url   string
+
+	options options
+
+	ssgignores func(path string) (ignore bool)
+	headers    headers
+	footers    footers
+	preferred  Set // Used to prefer html and ignore md files with identical names, as with the original ssg
+
+	result buildOutput
+}
+
+func (s *Ssg) Options() Options { return s.options }
+func (s *Ssg) Outputs() Outputs { return &s.result }
+
+// New returns a default [Ssg] with options.
+func New(src, dst, title, url string) Ssg {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+	ignores, err := prepare(src, dst)
+	if err != nil {
+		panic(err)
+	}
+	s := Ssg{
+		Src:        src,
+		Dst:        dst,
+		Title:      title,
+		Url:        url,
+		ssgignores: ignores.Ignore,
+		preferred:  make(Set),
+		headers:    newHeaders(HeaderDefault),
+		footers:    newFooters(FooterDefault),
+	}
+	return s
+}
+
+func NewWithOptions(src, dst, title, url string, opts ...Option) *Ssg {
+	s := New(src, dst, title, url)
+	s.With(opts...)
+	return &s
+}
+
+// Build builds static site from src.
+// If outputs is nil, the result will only be cached.
+// If outputs is non-nil, then the builder's outputs
+// will also be added to outputs.
+func Build(src, dst, title, url string, outputs Outputs, opts ...Option) ([]string, []OutputFile, error) {
+	withCachePrepended := append([]Option{Caching(true)}, opts...)
+	return build(NewWithOptions(
+		src,
+		dst,
+		title,
+		url,
+		withCachePrepended...,
+	),
+		outputs,
+	)
+}
+
+// Generate writes static site built from src to dst.
+// It creates a one-off [Ssg] that's used to generate a site right away.
+func Generate(src, dst, title, url string, opts ...Option) error {
+	return generate(NewWithOptions(
+		src,
+		dst,
+		title,
+		url,
+		opts...,
+	))
+}
+
+// Build creates a new result from a directory walk.
+// Build is where Ssg controls its outputs.
+func (s *Ssg) Build(outputs Outputs) ([]string, []OutputFile, error) {
+	return build(s, outputs)
+}
+
+// Generate builds from s.Src and writes the outputs to s.Dst
+func (s *Ssg) Generate() error {
+	return generate(s)
+}
+
+// With applies opts to s sequentially
+func (s *Ssg) With(opts ...Option) *Ssg {
+	for i := range opts {
+		opts[i](s)
+	}
+	return s
+}
+
+func (s *Ssg) collect(path string) error {
+	children, err := os.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for i := range children {
+		child := children[i]
+		base := child.Name()
+		pathChild := filepath.Join(path, base)
+
+		switch base {
+		case MarkerHeader:
+			data, err := ReadFile(pathChild)
+			if err != nil {
+				return err
+			}
+			err = s.headers.add(path, header{
+				Buffer:    bytes.NewBuffer(data),
+				titleFrom: GetTitleFrom(data),
+			})
+			if err != nil {
+				return err
+			}
+
+			continue
+
+		case MarkerFooter:
+			data, err := ReadFile(pathChild)
+			if err != nil {
+				return err
+			}
+			err = s.footers.add(path, bytes.NewBuffer(data))
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		ext := filepath.Ext(base)
+		if ext != ".html" {
+			continue
+		}
+		if s.preferred.Insert(pathChild) {
+			return fmt.Errorf("duplicate html file %s", path)
+		}
+	}
+
+	return nil
+}
+
+// core does 2 things:
+// - If path extension is not .md, then the current file will
+// simply be copied to outputs.
+// - If path has .md extension, it converts Markdown to HTML
+// and adds a new output with .html extension
+func (s *Ssg) core(path string, data []byte, d fs.DirEntry) (OutputFile, error) {
+	info, err := d.Info()
+	if err != nil {
+		return OutputFile{}, err
+	}
+	for i, hook := range s.options.hooks {
+		data, err = hook(path, data)
+		if err != nil {
+			return OutputFile{}, fmt.Errorf("hooks[%d]: error when building %s: %w", i, path, err)
+		}
+	}
+
+	// Copy non-Markdown and HTML files
+	if ext := filepath.Ext(path); ext != ".md" || s.preferred.Contains(
+		ChangeExt(path, ".md", ".html"),
+	) {
+		target, err := mirrorPath(s.Src, s.Dst, path)
+		if err != nil {
+			return OutputFile{}, err
+		}
+		// Just copy the file to the destination
+		return Output(
+			target,
+			path,
+			data,
+			info.Mode().Perm(),
+		), nil
+	}
+
+	target, err := mirrorPath(s.Src, s.Dst, path)
+	if err != nil {
+		return OutputFile{}, err
+	}
+
+	target = ChangeExt(target, ".md", ".html")
+	header := s.headers.choose(path)
+	footer := s.footers.choose(path)
+
+	// Copy, leave the underlying data in header unchanged
+	headerText := make([]byte, header.Len())
+	_ = copy(headerText, header.Bytes())
+
+	switch header.titleFrom {
+	case TitleFromH1:
+		headerText = AddTitleFromH1([]byte(s.Title), headerText, data)
+
+	case TitleFromTag:
+		headerText, data = AddTitleFromTag([]byte(s.Title), headerText, data)
+	}
+
+	// HTML output buffer
+	buf := bytes.NewBuffer(headerText)
+	buf.Write(ToHtml(data))
+	buf.Write(footer.Bytes())
+
+	for i, h := range s.options.hookGenerate {
+		b, err := h(buf.Bytes())
+		if err != nil {
+			return OutputFile{}, fmt.Errorf("hooksGenerate[%d] error when building %s: %w", i, path, err)
+		}
+		buf = bytes.NewBuffer(b)
+	}
+
+	return Output(
+		target,
+		path,
+		buf.Bytes(),
+		info.Mode().Perm(),
+	), nil
+}
+
+func (s *Ssg) Ignore(path string) bool {
+	return s.ssgignores(path)
+}
+
+func (s *Ssg) pront(l int) {
+	Fprintf(os.Stdout, "[ssg-go] wrote %d file(s) to %s\n", l, s.Dst)
+}
+
+func prepare(src, dst string) (*gitIgnorer, error) {
+	if src == "" {
+		return nil, fmt.Errorf("empty src")
+	}
+	if dst == "" {
+		return nil, fmt.Errorf("empty dst")
+	}
+	if src == dst {
+		return nil, fmt.Errorf("src is identical to dst: '%s'", src)
+	}
+
+	ssgignore := filepath.Join(src, SsgIgnore)
+	return ParseSsgIgnore(ssgignore)
+}
+
+func ParseSsgIgnore(path string) (*gitIgnorer, error) {
+	ignores, err := ignore.CompileIgnoreFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to parse ssgignore at %s: %w", path, err)
+	}
+
+	return &gitIgnorer{GitIgnore: ignores}, nil
+}
+
+type gitIgnorer struct {
+	*ignore.GitIgnore
+}
+
+func (i *gitIgnorer) Ignore(path string) bool {
+	if i == nil {
+		return false
+	}
+	if i.GitIgnore == nil {
+		return false
+	}
+	return i.MatchesPath(path)
+}
+
+// TODO: refactor
+func shouldIgnore(ignoreFn func(path string) (ignored bool), path, base string, d fs.DirEntry) (bool, error) {
+	isDot := strings.HasPrefix(base, ".")
+	isDir := d.IsDir()
+
+	switch {
+	case isDot && isDir:
+		return true, fs.SkipDir
+
+	// Ignore hidden files and dir
+	case isDot, isDir:
+		return true, nil
+
+	case ignoreFn(path):
+		return true, nil
+	}
+
+	// Ignore symlink
+	stat, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	if FileIs(stat, os.ModeSymlink) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// mirrorPath mirrors the target HTML file path under src to under dist
+//
+// i.e. if src="foo/src" and dst="foo/dist",
+// and path="foo/src/bar/baz.md"  newExt=".html",
+// then the return value will be foo/dist/bar/baz.html
+func mirrorPath(
+	src string,
+	dst string,
+	path string,
+) (
+	string,
+	error,
+) {
+	path, err := filepath.Rel(src, path)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dst, path), nil
+}

--- a/ssg_test.go
+++ b/ssg_test.go
@@ -1,0 +1,458 @@
+package ssg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+func TestToHTML(t *testing.T) {
+	type testCase struct {
+		md   string
+		html string
+	}
+
+	tests := []testCase{
+		{
+			md:   "",
+			html: "",
+		},
+		{
+			md:   "This is a paragraph",
+			html: "<p>This is a paragraph</p>\n",
+		},
+		{
+			md: `# Some h1
+Some paragraph`,
+			html: `<h1 id="some-h1">Some h1</h1>
+
+<p>Some paragraph</p>
+`,
+		},
+		{
+			md: `# Some h1
+Some paragraph
+
+## Some h2`,
+			html: `<h1 id="some-h1">Some h1</h1>
+
+<p>Some paragraph</p>
+
+<h2 id="some-h2">Some h2</h2>
+`,
+		},
+		{
+			md: `# Some h1
+Some paragraph
+
+<p>Embedded HTML paragraph</p>
+
+## Some h2`,
+			html: `<h1 id="some-h1">Some h1</h1>
+
+<p>Some paragraph</p>
+
+<p>Embedded HTML paragraph</p>
+
+<h2 id="some-h2">Some h2</h2>
+`,
+		},
+		{
+			md: `# Some h1
+Some paragraph
+
+<p>Embedded HTML paragraph</p>
+
+## Some h2
+
+Some paragraph2`,
+			html: `<h1 id="some-h1">Some h1</h1>
+
+<p>Some paragraph</p>
+
+<p>Embedded HTML paragraph</p>
+
+<h2 id="some-h2">Some h2</h2>
+
+<p>Some paragraph2</p>
+`,
+		},
+		{
+			md: `# Some h1
+Some paragraph
+
+<p>Embedded HTML paragraph</p>
+
+<h2 id="some-h2">Embedded HTML h2</h2>
+
+Some paragraph2`,
+			html: `<h1 id="some-h1">Some h1</h1>
+
+<p>Some paragraph</p>
+
+<p>Embedded HTML paragraph</p>
+
+<h2 id="some-h2">Embedded HTML h2</h2>
+
+<p>Some paragraph2</p>
+`,
+		},
+		{
+			md: `# Some h1
+Some paragraph
+
+<p>Embedded HTML paragraph</p>
+
+<h2>Embedded HTML h2</h2>
+
+Some paragraph2`,
+			html: `<h1 id="some-h1">Some h1</h1>
+
+<p>Some paragraph</p>
+
+<p>Embedded HTML paragraph</p>
+
+<h2>Embedded HTML h2</h2>
+
+<p>Some paragraph2</p>
+`,
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+		html := ToHtml([]byte(tc.md))
+		if actual := string(html); actual != tc.html {
+			t.Logf("len(expected)=%d, len(actual)=%d", len(html), len(actual))
+			t.Logf("expected:\n%s", tc.html)
+			t.Logf("actual:\n%s", actual)
+			t.Fatalf("unexpected HTML output from case %d", i+1)
+		}
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	t.Run("build-v2", func(t *testing.T) {
+		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
+			return s.Build(nil)
+		})
+	})
+}
+
+func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]string, []OutputFile, error)) {
+	root := "../testdata/johndoe.com"
+	src := filepath.Join(root, "/src")
+	dst := filepath.Join(root, "/dst")
+	title := "JohnDoe.com"
+	url := "https://johndoe.com"
+
+	err := os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+
+	s := New(src, dst, title, url)
+	_, outputs, err := buildFn(&s)
+	if err != nil {
+		t.Errorf("unexpected error from scan: %v", err)
+	}
+	if !s.preferred.Contains(filepath.Join(src, "/blog/index.html")) {
+		t.Fatalf("missing preferred html file /blog/index.html")
+	}
+
+	for i := range s.result.cache {
+		o := &s.result.cache[i]
+
+		if strings.HasSuffix(o.target, "_header.html") {
+			t.Fatalf("unexpected _header.html output in '%s'", o.target)
+		}
+		if strings.HasSuffix(o.target, "_footer.html") {
+			t.Fatalf("unexpected _footer.html output in '%s'", o.target)
+		}
+	}
+
+	titleFroms := map[string]TitleFrom{
+		"/_header.html":           TitleFromH1,
+		"/blog/_header.html":      TitleFromTag,
+		"/blog/2023/_header.html": TitleFromNone,
+	}
+
+	for h, from := range titleFroms {
+		filename := filepath.Join(src, h)
+		dirname := filepath.Dir(filename)
+		header, ok := s.headers.values[dirname]
+		if !ok {
+			t.Fatalf("missing header '%s' for dir '%s'", filename, dirname)
+		}
+		if header.titleFrom != from {
+			t.Fatalf("unexpected from '%d', expecting %d", header.titleFrom, from)
+		}
+	}
+
+	type expected struct {
+		subString string
+		titleFrom TitleFrom
+	}
+
+	expecteds := map[string]expected{
+		"/": {
+			titleFrom: TitleFromH1,
+			subString: "<!-- ROOT HEADER -->",
+		},
+		"/blog": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/2022": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/2022/3": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/2023": {
+			titleFrom: TitleFromNone,
+			subString: "<!-- HEADER FOR BLOG 2023 -->",
+		},
+		"/notes": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- NOTES HEADER -->",
+		},
+	}
+
+	for parentDir, e := range expecteds {
+		parentDir = filepath.Join(src, parentDir)
+		chosen := s.headers.choose(parentDir)
+		if chosen.titleFrom != e.titleFrom {
+			t.Fatalf("unexpected titleFrom at dir '%s' actual=%d, expecting=%d", parentDir, chosen.titleFrom, e.titleFrom)
+		}
+		if !bytes.Contains(chosen.Bytes(), []byte(e.subString)) {
+			t.Fatalf("missing expecting substr '%s' from dir %s", e.subString, parentDir)
+		}
+	}
+
+	expectedOutputs := map[string][]string{
+		"/index.html": {
+			"<title>Welcome to JohnDoe.com!</title>",
+		},
+		"/blog/2022/index.html": {
+			"<title>2022 Blog index</title>",
+			"<body><h1 id=\"blog-from-the-worst-year\">Blog from the worst year</h1>",
+		},
+		"/testconvert/index.html": {
+			"<!-- Header for testconvert -->",
+			"<title>Embedded-HTML should be correctly preserved</title>",
+		},
+	}
+
+	for path, e := range expectedOutputs {
+		path = filepath.Join(dst, path)
+		for i := range outputs {
+			o := &outputs[i]
+			if o.target != path {
+				continue
+			}
+			for j := range e {
+				s := e[j]
+				if bytes.Contains(o.data, []byte(s)) {
+					continue
+				}
+				t.Fatalf("missing expected substr '%s' from output %s", s, o.target)
+			}
+		}
+	}
+
+	err = os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Test that the library we use actually does what we want it to
+func TestSsgignore(t *testing.T) {
+	type testCase struct {
+		path     string
+		ignores  []string
+		expected bool
+	}
+
+	tests := []testCase{
+		{
+			ignores: []string{
+				"testignore",
+			},
+			path:     "testignore",
+			expected: true,
+		},
+		{
+			ignores: []string{
+				"testignore",
+			},
+			path:     "testignore/",
+			expected: true,
+		},
+		{
+			ignores: []string{
+				"testignore",
+			},
+			path:     "testignore/one",
+			expected: true,
+		},
+		{
+			ignores: []string{
+				"test*",
+			},
+			path:     "testignore/one",
+			expected: true,
+		},
+		{
+			ignores: []string{
+				"testignore",
+				"!prefix/testignore",
+			},
+			path:     "prefix/testignore/",
+			expected: false,
+		},
+		{
+			ignores: []string{
+				"!prefix/testignore",
+				"testignore",
+			},
+			path:     "prefix/testignore/",
+			expected: true,
+		},
+		{
+			ignores: []string{
+				"testignore",
+				"!testignore/important/",
+			},
+			path:     "testignore/important/data",
+			expected: false,
+		},
+		{
+			ignores: []string{
+				"testignore",
+				"!testignore/important*",
+			},
+			path:     "testignore/important/data",
+			expected: false,
+		},
+		{
+			ignores: []string{
+				"testignore/trash/**",
+				"#!testignore/trash/**/keep", // Comment
+			},
+			path:     "testignore/trash/some/path/keep/data",
+			expected: true,
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+		ignores := ignore.CompileIgnoreLines(tc.ignores...)
+		if ignores == nil {
+			panic("bad ignore lines")
+		}
+
+		ignorer := &gitIgnorer{GitIgnore: ignores}
+		ignored := ignorer.Ignore(tc.path)
+		if tc.expected == ignored {
+			continue
+		}
+
+		t.Fatalf("[case %d] unexpected ignore value, expecting %v, got %v", i+1, tc.expected, ignored)
+	}
+}
+
+// TestBuildAndWriteOut tests that Build+WriteOut both
+// work as expected (identical to Generate)
+func TestBuildAndWriteOut(t *testing.T) {
+	root := "../testdata/johndoe.com"
+	src := filepath.Join(root, "/src")
+	dstGenerate := filepath.Join(root, "/dstGenerate")
+	dstBuild := filepath.Join(root, "/dstBuild")
+	title := "JohnDoe.com"
+	url := "https://johndoe.com"
+
+	err := os.RemoveAll(dstGenerate)
+	if err != nil {
+		panic(err)
+	}
+	err = os.RemoveAll(dstBuild)
+	if err != nil {
+		panic(err)
+	}
+	// Build with nil outputs (no concurrent writer)
+	files, cache, err := Build(src, dstBuild, title, url, nil)
+	if err != nil {
+		panic(err)
+	}
+	err = WriteOutSlice(cache, 1)
+	if err != nil {
+		panic(err)
+	}
+	stat, err := os.Stat(src)
+	if err != nil {
+		panic(err)
+	}
+	err = GenerateMetadata(src, dstBuild, url, files, cache, stat.ModTime())
+	if err != nil {
+		panic(err)
+	}
+	// Generate output
+	err = Generate(src, dstGenerate, title, url)
+	if err != nil {
+		panic(err)
+	}
+	// Assert equal
+	testDeepEqual(t, dstGenerate, dstBuild)
+}
+
+func TestErrors(t *testing.T) {
+	retBreakPipe := func() error {
+		return ErrBreakPipelines
+	}
+	wrapBreakPipe := func(err error) error {
+		return fmt.Errorf("foo bar %w: %w", err, ErrBreakPipelines)
+	}
+	retSkipCore := func() error {
+		return ErrSkipCore
+	}
+	wrapSkipCore := func(err error) error {
+		return fmt.Errorf("foo bar %w: %w", err, ErrSkipCore)
+	}
+
+	tests := map[error][]error{
+		ErrBreakPipelines: {
+			retBreakPipe(),
+			wrapBreakPipe(errors.New("some error")),
+			fmt.Errorf("%w-%w", ErrBreakPipelines, ErrSkipCore),
+			fmt.Errorf("%w%w", ErrBreakPipelines, ErrSkipCore),
+			fmt.Errorf("%w%w", ErrSkipCore, ErrBreakPipelines),
+		},
+		ErrSkipCore: {
+			retSkipCore(),
+			wrapSkipCore(errors.New("some other error")),
+		},
+	}
+
+	for target, errs := range tests {
+		for i := range errs {
+			if errors.Is(errs[i], target) {
+				continue
+			}
+			t.Fatalf("unexpected unwrapping error %v for case %d", target, i+1)
+		}
+	}
+}

--- a/title.go
+++ b/title.go
@@ -1,0 +1,147 @@
+package ssg
+
+import (
+	"bufio"
+	"bytes"
+)
+
+type TitleFrom uint8
+
+const (
+	TitleFromNone TitleFrom = iota
+	TitleFromH1
+	TitleFromTag
+
+	TargetFromH1  = "{{from-h1}}"
+	TargetFromTag = "{{from-tag}}"
+
+	keyTitleFromH1  = "# "          // The first h1 tag is used as document header title
+	keyTitleFromTag = ":ssg-title " // The first line starting with :ssg-title will be parsed as document header title
+
+	placeholderFromH1  = "<title>" + TargetFromH1 + "</title>"
+	placeholderFromTag = "<title>" + TargetFromTag + "</title>"
+)
+
+func GetTitleFromH1(markdown []byte) []byte {
+	k := []byte(keyTitleFromH1)
+	s := bufio.NewScanner(bytes.NewBuffer(markdown))
+
+	var title []byte
+	for s.Scan() {
+		line := s.Bytes()
+		if !bytes.HasPrefix(line, k) {
+			continue
+		}
+		parts := bytes.Split(line, k)
+		if len(parts) != 2 {
+			continue
+		}
+
+		title = parts[1]
+		break
+	}
+
+	return title
+}
+
+func GetTitleFromTag(markdown []byte) []byte {
+	k := []byte(keyTitleFromTag)
+	s := bufio.NewScanner(bytes.NewBuffer(markdown))
+
+	var title []byte
+	for s.Scan() {
+		line := s.Bytes()
+		if !bytes.HasPrefix(line, k) {
+			continue
+		}
+		parts := bytes.Split(line, k)
+		if len(parts) != 2 {
+			continue
+		}
+
+		title = parts[1]
+		break
+	}
+
+	return title
+}
+
+// AddTitleFromH1 finds the first h1 in markdown and uses the h1 title
+// to write to <title> tag in header.
+func AddTitleFromH1(d []byte, header []byte, markdown []byte) []byte {
+	target := []byte(TargetFromH1)
+	title := GetTitleFromH1(markdown)
+	if len(title) == 0 {
+		header = bytes.Replace(header, target, d, 1)
+		return header
+	}
+
+	header = bytes.Replace(header, target, title, 1)
+	return header
+}
+
+// AddTitleFromTag finds title in markdown and then write it to <title> tag in header.
+// It also deletes the tag line from markdown.
+func AddTitleFromTag(
+	d []byte,
+	header []byte,
+	markdown []byte,
+) (
+	[]byte,
+	[]byte,
+) {
+	key := []byte(keyTitleFromTag)
+	target := []byte(TargetFromTag)
+	s := bufio.NewScanner(bytes.NewBuffer(markdown))
+
+	for s.Scan() {
+		line := s.Bytes()
+		if !bytes.HasPrefix(line, key) {
+			continue
+		}
+		parts := bytes.Split(line, key)
+		if len(parts) != 2 {
+			continue
+		}
+
+		line = trimRightWhitespace(line)
+		title := parts[1]
+
+		header = bytes.Replace(header, target, title, 1)
+		markdown = bytes.Replace(markdown, append(line, []byte{'\n', '\n'}...), nil, 1)
+		return header, markdown
+	}
+
+	// Remove target and use default header string
+	header = bytes.Replace(header, target, []byte(d), 1)
+	return header, markdown
+}
+
+func IsTargetFromH1(b []byte) bool {
+	return bytes.Contains(b, []byte(TargetFromH1))
+}
+
+func IsTargetFromTag(b []byte) bool {
+	return bytes.Contains(b, []byte(TargetFromTag))
+}
+
+func GetTitleFrom(b []byte) TitleFrom {
+	if IsTargetFromH1(b) {
+		return TitleFromH1
+	}
+	if IsTargetFromTag(b) {
+		return TitleFromTag
+	}
+
+	return TitleFromNone
+}
+
+func trimRightWhitespace(b []byte) []byte {
+	return bytes.TrimRightFunc(b, func(r rune) bool {
+		switch r {
+		case ' ', '\t':
+			return true
+		}
+		return false
+	})
+}

--- a/title_test.go
+++ b/title_test.go
@@ -1,0 +1,236 @@
+package ssg_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/soyart/ssg-go"
+)
+
+func TestTitleFromH1(t *testing.T) {
+	type testCase struct {
+		head          string
+		markdown      string
+		expectedTitle string
+		expectedHead  string
+	}
+
+	tests := []testCase{
+		{
+			head: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{from-h1}}</title>
+</head>`,
+			markdown: `
+Mar 24 1998
+
+# Some h1
+
+Some para`,
+			expectedTitle: "Some h1",
+			expectedHead: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Some h1</title>
+</head>`,
+		},
+		{
+			head: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{from-h1}}</title>
+</head>`,
+			markdown: `
+Mar 24 1998
+
+:ssg-title Not a title
+
+## Some h2
+
+# Some h1
+
+Some para`,
+			expectedTitle: "Some h1",
+			expectedHead: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Some h1</title>
+</head>`,
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+		title := ssg.GetTitleFromH1([]byte(tc.markdown))
+		if string(title) != tc.expectedTitle {
+			t.Logf("Expected='%s'", tc.expectedTitle)
+			t.Logf("Actual='%s'", string(title))
+			t.Fatalf("unexpected title for case %d", i+1)
+		}
+
+		actual := ssg.AddTitleFromH1([]byte{}, []byte(tc.head), []byte(tc.markdown))
+		if !bytes.Equal(actual, []byte(tc.expectedHead)) {
+			t.Logf("Expected:\nSTART===\n%s\nEND===", tc.expectedHead)
+			t.Logf("Actual:\nSTART===\n%s\nEND===", actual)
+
+			t.Fatalf("unexpected value for case %d", i+1)
+		}
+	}
+}
+
+func TestTitleFromTag(t *testing.T) {
+	type testCase struct {
+		head             string
+		markdown         string
+		expectedTitle    string
+		expectedHead     string
+		expectedMarkdown string
+	}
+
+	tests := []testCase{
+		{
+			head: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{from-tag}}</title>
+</head>`,
+			markdown: `
+Mar 24 1998
+
+:ssg-title My title
+
+# Some h1
+
+Some para`,
+			expectedTitle: "My title",
+			expectedHead: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>My title</title>
+</head>`,
+			expectedMarkdown: `
+Mar 24 1998
+
+# Some h1
+
+Some para`,
+		},
+		{
+			head: `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{from-tag}}</title>
+</head>`,
+			markdown: `
+Mar 24 1998
+
+	:ssg-title Not actually title
+
+:ssg-title This is the title
+
+# Some h1
+
+Some para  `,
+			expectedTitle: "This is the title",
+			expectedHead: `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>This is the title</title>
+</head>`,
+			expectedMarkdown: `
+Mar 24 1998
+
+	:ssg-title Not actually title
+
+# Some h1
+
+Some para  `,
+		},
+		{
+			head: `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{from-tag}}</title>
+</head>`,
+			markdown: `
+Mar 24 1998
+
+	:ssg-title Not actually title
+
+:ssg-title This is the title
+
+:ssg-title This should persist
+
+# Some h1
+
+Some para  `,
+			expectedTitle: "This is the title",
+			expectedHead: `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>This is the title</title>
+</head>`,
+			expectedMarkdown: `
+Mar 24 1998
+
+	:ssg-title Not actually title
+
+:ssg-title This should persist
+
+# Some h1
+
+Some para  `,
+		},
+	}
+
+	for i := range tests {
+		tc := &tests[i]
+		title := ssg.GetTitleFromTag([]byte(tc.markdown))
+		if string(title) != tc.expectedTitle {
+			t.Logf("Expected='%s'", tc.expectedTitle)
+			t.Logf("Actual='%s'", string(title))
+			t.Fatalf("unexpected title for case %d", i+1)
+		}
+
+		head, markdown := ssg.AddTitleFromTag([]byte{}, []byte(tc.head), []byte(tc.markdown))
+		if !bytes.Equal(head, []byte(tc.expectedHead)) {
+			t.Logf("Expected:\nSTART===\n%s\nEND===", tc.expectedHead)
+			t.Logf("Actual:\nSTART===\n%s\nEND===", head)
+			t.Logf("len(expected) = %d, len(actual) = %d", len(tc.expectedHead), len(head))
+
+			t.Fatalf("unexpected substituted header value for case %d", i+1)
+		}
+
+		if md := string(markdown); md != tc.expectedMarkdown {
+			t.Logf("Original:\nSTART===\n%s\nEND===", tc.markdown)
+			t.Logf("Expected:\nSTART===\n%s\nEND===", tc.expectedMarkdown)
+			t.Logf("Actual:\nSTART===\n%s\nEND===", md)
+			t.Logf("len(expected) = %d, len(actual) = %d", len(tc.expectedMarkdown), len(markdown))
+
+			for i := range tc.expectedMarkdown {
+				e := tc.expectedMarkdown[i]
+				a := md[i]
+				t.Logf("%d: diff=%v actual='%c', expected='%c'", i, e != a, e, a)
+			}
+
+			t.Fatalf("unexpected modified markdown value for case %d", i+1)
+		}
+	}
+}


### PR DESCRIPTION
Our [previous repo](https://github.com/soyart/ssg) had some serious issues regarding cyclic dependencies and self-pinning.

So we'll separate all Go modules into its own repo, and have the old repo import that from Nix flake instead.

This PR will initialize the new repo for ssg-go